### PR TITLE
Fix 'main' value in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "jquery": ">=1.7"
   },
-  "main": "./restive.js",
+  "main": "dist/restive.min.js",
   "keywords": [
     "restive",
     "restive.js",


### PR DESCRIPTION
Fix 'main' value in bower.json, so tools like wiredep can find the js file
